### PR TITLE
Use renamed configuration option io.tmp.dirs

### DIFF
--- a/peel-extensions/src/main/resources/reference.flink-1.11.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.11.0.conf
@@ -1,5 +1,5 @@
-# include common flink configuration
-include "reference.flink.conf"
+# include common Flink 1.11 configuration
+include "reference.flink-1.11.conf"
 
 system {
   flink {

--- a/peel-extensions/src/main/resources/reference.flink-1.11.1.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.11.1.conf
@@ -1,5 +1,5 @@
-# include common flink configuration
-include "reference.flink.conf"
+# include common Flink 1.11 configuration
+include "reference.flink-1.11.conf"
 
 system {
   flink {

--- a/peel-extensions/src/main/resources/reference.flink-1.11.2.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.11.2.conf
@@ -1,5 +1,5 @@
-# include common flink configuration
-include "reference.flink.conf"
+# include common Flink 1.11 configuration
+include "reference.flink-1.11.conf"
 
 system {
   flink {

--- a/peel-extensions/src/main/resources/reference.flink-1.11.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.11.conf
@@ -1,0 +1,12 @@
+# include common Flink configuration
+include "reference.flink.conf"
+
+system {
+  flink {
+    config {
+      yaml {
+        io.tmp.dirs = ${system.flink.tmp.dirs}
+      }
+    }
+  }
+}

--- a/peel-extensions/src/main/resources/reference.flink.conf
+++ b/peel-extensions/src/main/resources/reference.flink.conf
@@ -2,6 +2,7 @@ system {
     flink {
         user = ${system.default.user}
         group = ${system.default.group}
+        tmp.dirs = "/tmp/flink"
         path {
             isShared = ${system.default.path.isShared}
             archive.dst = ${app.path.systems}
@@ -24,7 +25,6 @@ system {
                 env.pid.dir = "/tmp/flink-pid"
                 parallelism.default = ${system.default.config.parallelism.total}
                 jobmanager.rpc.address = "localhost"
-                taskmanager.tmp.dirs = "/tmp/flink"
                 taskmanager.numberOfTaskSlots = ${system.default.config.parallelism.per-node}
             }
             # log4j.properties entries

--- a/peel-extensions/src/main/scala/org/peelframework/flink/beans/system/FlinkYarnSession.scala
+++ b/peel-extensions/src/main/scala/org/peelframework/flink/beans/system/FlinkYarnSession.scala
@@ -84,7 +84,7 @@ class FlinkYarnSession(
     }
 
     val hosts = config.getStringList(s"system.$configKey.config.slaves").asScala
-    val paths = config.getString(s"system.$configKey.config.yaml.taskmanager.tmp.dirs").split(':')
+    val paths = config.getString(s"system.$configKey.tmp.dirs").split(':')
 
     val futureInitOps = Future.traverse(hosts)(host => Future {
       logger.info(s"Initializing Flink tmp directories '${paths.mkString(":")}' at $host")


### PR DESCRIPTION
Fixes warning in Flink log:

2020-11-03 21:16:35,409 WARN  org.apache.flink.configuration.Configuration                 [] - Config uses deprecated configuration key 'taskmanager.tmp.dirs' instead of proper key 'io.tmp.dirs'